### PR TITLE
Corrección error versiones build.gradle

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 android {
     namespace = "com.example.kpi"
     compileSdk = flutter.compileSdkVersion
-    ndkVersion = flutter.ndkVersion
+    ndkVersion = "27.0.12077973"
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
@@ -28,7 +28,7 @@ android {
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion
-        targetSdk = flutter.targetSdkVersion
+        targetSdk = 30
         versionCode = flutter.versionCode
         versionName = flutter.versionName
     }


### PR DESCRIPTION
El archivo build.gradle tenía un error en las versiones nkd y sdk. Las he modificado para eliminar los errores. Revísenlo para ver si a ustedes les aparece algo.